### PR TITLE
Update readme with correct provider name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ mercurial repositories.
 Resource/Provider
 =================
 
-This cookbook includes LWRPs for managing: hg
+This cookbook includes LWRPs for managing: mercurial
 
 hg
 --
@@ -29,7 +29,7 @@ hg
 
 # Example
 
-	hg "/home/site/checkouts/www" do
+	mercurial "/home/site/checkouts/www" do
 		repository "ssh://hg@bitbucket.org/niallsco/chef-hg"
 		reference "tip"
 		key "/home/site/.ssh/keyname"


### PR DESCRIPTION
The provider name in the readme was incorrect, if you used the example
code you would get an error on the chef run, e.g.:

NameError: Cannot find a resource for hg on ubuntu version 11.04  

Switching to use "mercurial" as the provider name resolved this error and cause the mercurial repo to be cloned.
