### PR TITLE
[COOK-2918] Fix mercurial::pip fails without build tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Cookbooks
 ---------
 
 * python
+* build-essential
 
 Attributes
 ==========

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,3 +13,4 @@ end
 
 depends           "windows"
 depends           "python"
+depends           "build-essential"

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -18,6 +18,7 @@
 #
 
 include_recipe "python"
+include_recipe "build-essential"
 
 python_pip "mercurial" do
   action :upgrade


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2918

mercurial requires compiles on installation from source.
So `mercurial::pip` should be include build-essential before calling python_pip.
