### PR TITLE
allow the windows package name to be correct (and possibly overridden)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,5 +8,6 @@ when "windows"
     default['hg']['windows_arch'] = "x86"
   end
   default['hg']['version'] = "2.4.0"
+  default['hg']['windows_package'] = "Mercurial #{node['hg']['version']} (#{node['hg']['windows_arch']})"
   default['hg']['windows_url'] = "http://mercurial.selenic.com/release/windows/mercurial-#{node['hg']['version']}-#{node['hg']['windows_arch']}.msi"
 end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -19,7 +19,7 @@
 
 case node['platform']
 when "windows"
-  windows_package "Mercurial" do
+  windows_package node['hg']['windows_package'] do
     source node['hg']['windows_url']
     action :install
   end


### PR DESCRIPTION
The `windows_package` LWRP uses the package name to look for the installed package as it's listed in "Programs and Features". The name of the Mercurial MSI in that list is "Mercurial <version> (<architecture>)" such as "Mercurial 2.4.0 (x64)".

Also by having this as an attribute it makes it possible for someone to override it to set it to something like "TortoiseHg 2.10.0 (x64)" if they wanted to install the TortoiseHg MSI instead of just Mercurial.
