### PR TITLE
Check if "use_inline_resources" method is defined

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -1,4 +1,4 @@
-use_inline_resources
+use_inline_resources if defined?(use_inline_resources) 
 
 # Support whyrun
 def whyrun_supported?


### PR DESCRIPTION
Can't use mercurial with chef < 11

Same issue as opscode-cookbooks/ark#25
