### PR TITLE
Updated call to windows_package per deprecation warning

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -19,7 +19,7 @@
 
 case node['platform']
 when "windows"
-  windows_package "Mercurial" do
+  package "Mercurial" do
     source node['hg']['windows_url']
     action :install
   end


### PR DESCRIPTION
The `windows_package` resource call has been deprecated in favor of just using the `package` resource as `windows_package` is included in Chef Client >= 12.6. This updates the recipe to just us the generic `package` resource and let Chef figure out how to handle it. Tested using the mwrock/Windows2012R2 box from Atlas in Test Kitchen.

An additional note for testing, it may take two converges because the winrm session needs to be reopened to pick up the environment change for the `hg` command.