### PR TITLE
Issue-22: update mercurial package download URL to mercurial-scm.org.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,5 +8,5 @@ when "windows"
     default['hg']['windows_arch'] = "x86"
   end
   default['hg']['version'] = "2.4.0"
-  default['hg']['windows_url'] = "http://mercurial.selenic.com/release/windows/mercurial-#{node['hg']['version']}-#{node['hg']['windows_arch']}.msi"
+  default['hg']['windows_url'] = "http://www.mercurial-scm.org/release/windows/mercurial-#{node['hg']['version']}-#{node['hg']['windows_arch']}.msi"
 end


### PR DESCRIPTION
This PR is being opened to address Issue-22: Mercurial Download URL has Moved.

All it does is update the attribute from which the Mercurial package is downloaded to pull from `http://www.mercurial-scm.org` instead of `http://mercurial.selenic.com`.
